### PR TITLE
Add support for Audio streams

### DIFF
--- a/lib/libav/reader.rb
+++ b/lib/libav/reader.rb
@@ -239,6 +239,9 @@ class Libav::Reader
                                  :width => p[:width],
                                  :height => p[:height],
                                  :afs => @afs && @afs[av_stream[:index]])
+      when :audio
+        Libav::Stream::Audio.new(:reader => self,
+                                 :av_stream => av_stream)
       else
         Libav::Stream::Unsupported.new(:reader => self,
                                         :av_stream => av_stream)


### PR DESCRIPTION
Audio streams wasn't supported, this PR implements basic functionally so that they can be decoded. This is just bare minimum and enough for most simple cases. Audio decoding is very similar to video decoding. Basically need to know just `sample_format`, `sample_rate`, `channels` and use decoded data from frame.
